### PR TITLE
Added trim to name set so items with trailing white space still match…

### DIFF
--- a/src/main/java/testrail/testrail/JunitResults/Testcase.java
+++ b/src/main/java/testrail/testrail/JunitResults/Testcase.java
@@ -29,7 +29,7 @@ public class Testcase {
     private Failure failure;
 
     @XmlAttribute
-    public void setName(String name) { this.name = name; }
+    public void setName(String name) { this.name = name.trim(); }
     @XmlElement(name = "failure")
     public void setFailure(Failure failure) { this.failure = failure; }
 

--- a/src/main/java/testrail/testrail/JunitResults/Testsuite.java
+++ b/src/main/java/testrail/testrail/JunitResults/Testsuite.java
@@ -35,7 +35,7 @@ public class Testsuite {
     private List<Testcase> cases;
     private List<Testsuite> suits;
     @XmlAttribute
-    public void setName(String name) { this.name = name; }
+    public void setName(String name) { this.name = name.trim(); }
     @XmlAttribute
     public void setFailures(int failures) { this.failures = failures; }
     @XmlAttribute

--- a/src/main/java/testrail/testrail/TestRailObjects/Case.java
+++ b/src/main/java/testrail/testrail/TestRailObjects/Case.java
@@ -32,7 +32,7 @@ public class Case {
     }
 
     public void setTitle(String title) {
-        this.title = title;
+        this.title = title.trim();
     }
 
     public void setSectionId(int sectionId) { this.sectionId = sectionId; }

--- a/src/main/java/testrail/testrail/TestRailObjects/Milestone.java
+++ b/src/main/java/testrail/testrail/TestRailObjects/Milestone.java
@@ -7,7 +7,7 @@ public class Milestone {
     private String id;
     private String name;
     public void setId(String id) { this.id = id; }
-    public void setName(String name) { this.name = name; }
+    public void setName(String name) { this.name = name.trim(); }
     public String getId() { return this.id; }
     public String getName() { return  this.name; }
 }

--- a/src/main/java/testrail/testrail/TestRailObjects/Project.java
+++ b/src/main/java/testrail/testrail/TestRailObjects/Project.java
@@ -30,7 +30,7 @@ public class Project {
     }
 
     public void setName(String name) {
-        _name = name;
+        _name = name.trim();
     }
 
     public int getId() {

--- a/src/main/java/testrail/testrail/TestRailObjects/Section.java
+++ b/src/main/java/testrail/testrail/TestRailObjects/Section.java
@@ -32,7 +32,7 @@ public class Section {
     }
     public void  setSuiteId(int suiteId) { this.suiteId = suiteId; }
     public void setName(String name) {
-        this.name = name;
+        this.name = name.trim();
     }
     public void setParentId(String id) { this.parentId = id; }
 

--- a/src/main/java/testrail/testrail/TestRailObjects/Suite.java
+++ b/src/main/java/testrail/testrail/TestRailObjects/Suite.java
@@ -30,7 +30,7 @@ public class Suite {
     }
 
     public void setName(String name) {
-        this.name = name;
+        this.name = name.trim();
     }
 
     public int getId() {


### PR DESCRIPTION
… (testrail API trims after post)

The test rail API trims names of cases, suites, etc. So, if a case had a trailing whitespace in the name, it never matched the list of existing cases and constantly created duplicates.
