### PR TITLE
fix for 0s elapsed time that is not supported by testrail

### DIFF
--- a/src/main/java/testrail/testrail/TestRailObjects/Result.java
+++ b/src/main/java/testrail/testrail/TestRailObjects/Result.java
@@ -45,6 +45,6 @@ public class Result {
     public String getComment() { return this.comment; }
 
     public String getElapsedTimeString() {
-        return elapsed.intValue() + "s";
+        return Math.max(1, elapsed.intValue()) + "s";
     }
 }


### PR DESCRIPTION
The minimum value for elapsed time supported by Testrail is 1s:
https://discuss.gurock.com/t/elapsed-field-datatype-api-question/1089/27
